### PR TITLE
Feature/only target none dead targets

### DIFF
--- a/Battle/init/actions/actions.lua
+++ b/Battle/init/actions/actions.lua
@@ -115,4 +115,16 @@ action_build:setActionFunction( function(source_entity, target_entity)
 end)
 table.insert(actions, action_build:getAction())
 
+-- 8. Guard Breaker ----------------------------------------------------------------------------------------------------
+regular_attack_action_build:reset()
+regular_attack_action_build:setId(8)
+regular_attack_action_build:setName("Guard Breaker")
+regular_attack_action_build:setDescription("Breaks a single target's guard, used for debug.")
+regular_attack_action_build:setStartPiece(BATTLE_ACTION_PIECE_BORDER)
+regular_attack_action_build:setEndPiece(BATTLE_ACTION_PIECE_BORDER)
+regular_attack_action_build:setTarget(BATTLE_TARGET_SINGLE_ENEMY)
+regular_attack_action_build:setGuardDamage(9999999)
+regular_attack_action_build:setDirectDamage(0)
+table.insert(actions, regular_attack_action_build:getAction())
+
 return actions

--- a/Battle/model/entities/NullEntity.lua
+++ b/Battle/model/entities/NullEntity.lua
@@ -11,7 +11,6 @@ local NullEntity = class(function(self)
     -- Stats
     self.max_hp = 1
     self.hp = 1
-    self.is_alive = true
     
     self.strength = 0
     self.agility = 0
@@ -58,7 +57,7 @@ end)
 -- getHealed: int -> None
 -- The entity recovers points to their hp if its alive
 function NullEntity.getHealed(self, points)
-  if self.is_alive then
+  if self:isAlive() then
     self.hp = math.min(self.max_hp, self.hp + points)
   end
 end
@@ -66,9 +65,6 @@ end
 -- getAttackedDirectly: int -> None
 -- The entity loses hp equal to damage
 function NullEntity.getAttackedDirectly(self, damage)
-    if (self.hp - damage) <= 0 then
-      self.is_alive = false
-    end
     self.hp = math.max(0, self.hp - damage)
 end
 
@@ -114,7 +110,6 @@ end
 -- revive: None -> None
 -- The entity is revived and their hp is setted to 1 if it was less than one
 function NullEntity.revive(self)
-    self.is_alive = true
     self.hp = math.max(1, self.hp)
 end
 
@@ -122,6 +117,16 @@ end
 -- Checks if guard is broken
 function NullEntity.isGuardBroken(self)
     return self.guard:isGuardBroken()
+end
+
+-- restOneTurn: None -> None
+-- Recovers a small amount of stats for the turn
+function NullEntity.restOneTurn(self)
+    if self.guard:isGuardBroken() then
+        self.guard:mediumRecovery()
+    else
+        self.guard:smallRecovery()
+    end
 end
 
 -- getters
@@ -234,7 +239,7 @@ function NullEntity.getGuard(self)
 end
 
 function NullEntity.isAlive(self)
-  return self.is_alive
+  return self.hp ~= 0
 end
 
 function NullEntity.getActions(self)

--- a/Battle/model/entity_getter/TargetGetter.lua
+++ b/Battle/model/entity_getter/TargetGetter.lua
@@ -37,6 +37,7 @@ end
 -- This includes the every entity in the oposing party
 function TargetGetter.getTargetSingleEnemy(self, entity)
     local enemy_party_members = self:getEntityEnemyPartyMembers(entity)
+    enemy_party_members = self:_getNonDeadEntitiesFromEntityList(enemy_party_members)
     return self:getSingleTargetsFromEntityList(enemy_party_members)
 end
 
@@ -67,6 +68,17 @@ function TargetGetter.getTargetAllEnemies(self, entity)
     return {enemies}
 end
 
+-- _getNonDeadEntitiesFromEntityList: list(Entity) -> list(Entity)
+-- takes a list of entities and returns a list with the entities of that list that are not dead
+function TargetGetter._getNonDeadEntitiesFromEntityList(self, entity_list)
+    local aux = {}
+    for _, entity in pairs(entity_list) do
+        if entity:isAlive() then
+            table.insert(aux, entity)
+        end
+    end
+    return aux
+end
 
 
 return TargetGetter

--- a/Battle/model/guard/KnightGuard.lua
+++ b/Battle/model/guard/KnightGuard.lua
@@ -25,4 +25,22 @@ function KnightGuard.getMaxGuard(self)
     return math.floor(0.3*aux + 0.7 * math.pow(aux, math.sqrt(rct/95)))
 end
 
+-- smallRecovery: None -> None
+-- recovers a small amount of guard
+function KnightGuard.smallRecovery(self)
+    self:restoreGuard(math.floor(0.05*self:getMaxGuard()))
+end
+
+-- mediumRecovery: None -> None
+-- recovers half of its guard
+function KnightGuard.mediumRecovery(self)
+    self:restoreGuard(math.floor(0.5*self:getMaxGuard()))
+end
+
+-- fullRecovery: None -> None
+-- recovers maximum guard
+function KnightGuard.fullRecovery(self)
+    self:restoreGuard(self:getMaxGuard())
+end
+
 return KnightGuard

--- a/Battle/model/guard/NullGuard.lua
+++ b/Battle/model/guard/NullGuard.lua
@@ -60,6 +60,27 @@ function NullGuard.readjustGuard(self)
     self.current_guard = (old_guard/old_max_guard)*self.max_guard
 end
 
+-- smallRecovery: None -> None
+-- does nothing
+function NullGuard.smallRecovery(self)
+end
+
+-- mediumRecovery: None -> None
+-- does nothing
+function NullGuard.mediumRecovery(self)
+end
+
+-- mediumRecovery: None -> None
+-- does nothing
+function NullGuard.fullRecovery(self)
+end
+
+
+-- smallRecover: None -> None
+-- does nothing
+function NullGuard.smallRecover(self)
+end
+
 -- getter
 function NullGuard.getCurrentGuard(self)
     return self.current_guard

--- a/Battle/model/guard/RogueGuard.lua
+++ b/Battle/model/guard/RogueGuard.lua
@@ -25,4 +25,22 @@ function RogueGuard.getMaxGuard(self)
     return math.floor(math.pow(aux, math.sqrt(rct/90)))
 end
 
+-- smallRecovery: None -> None
+-- recovers a small amount of guard
+function RogueGuard.smallRecovery(self)
+    self:restoreGuard(math.floor(0.05*self:getMaxGuard()))
+end
+
+-- mediumRecovery: None -> None
+-- recovers half of its guard
+function RogueGuard.mediumRecovery(self)
+    self:restoreGuard(math.floor(0.7*self:getMaxGuard()))
+end
+
+-- fullRecovery: None -> None
+-- recovers maximum guard
+function RogueGuard.fullRecovery(self)
+    self:restoreGuard(self:getMaxGuard())
+end
+
 return RogueGuard

--- a/Battle/model/turns/RandomActionTurn.lua
+++ b/Battle/model/turns/RandomActionTurn.lua
@@ -35,14 +35,16 @@ function RandomActionTurn.start(self)
 
     -- Choose random targets depending on the first action
     local target_getter = ctrl:getTargetGetter()
-    local enemy_target = target_getter:getEntityEnemyPartyMembers(self.entity)[math.random(1, (# target_getter:getEntityEnemyPartyMembers(self.entity)))]
-    local ally_target = target_getter:getEntityPartyMembers(self.entity)[math.random(1,(# target_getter:getEntityPartyMembers(self.entity)))]
+    local possible_enemy_targets = target_getter:getTargetSingleEnemy(self.entity)
+    local enemy_target = possible_enemy_targets[math.random(1, (# possible_enemy_targets))]
+    local possible_ally_targets = target_getter:getTargetSinglePartyMember(self.entity)
+    local ally_target = possible_ally_targets[math.random(1,(# possible_ally_targets))]
 
     local target_behaviour = {}
     target_behaviour[BATTLE_TARGET_SELF] = {self.entity}
-    target_behaviour[BATTLE_TARGET_SINGLE_PARTY_MEMBER] = {ally_target}
+    target_behaviour[BATTLE_TARGET_SINGLE_PARTY_MEMBER] = ally_target
     target_behaviour[BATTLE_TARGET_ALL_PARTY_MEMBER] = target_getter:getTargets(self.entity, BATTLE_TARGET_ALL_PARTY_MEMBER)[1]
-    target_behaviour[BATTLE_TARGET_SINGLE_ENEMY] = {enemy_target}
+    target_behaviour[BATTLE_TARGET_SINGLE_ENEMY] = enemy_target
     target_behaviour[BATTLE_TARGET_ALL_ENEMIES] = target_getter:getTargets(self.entity, BATTLE_TARGET_ALL_ENEMIES)[1]
 
     local entities = {}

--- a/Battle/model/turns/Turn.lua
+++ b/Battle/model/turns/Turn.lua
@@ -16,6 +16,7 @@ end)
 function Turn.start(self)
     self.actions = {}
     self.target_action_entities = {}
+    self.entity:restOneTurn()
 end
 
 -- chooseActions: list(Action), list(list(Entity)) -> None

--- a/Global/entities.lua
+++ b/Global/entities.lua
@@ -27,7 +27,7 @@ entity["b_aura_prof"] = 1
 entity["b_spirit_prof"] = 1
 entity["b_instinct_prof"] = 4
 
-entity["actions"] = {1,4,5,6,7}
+entity["actions"] = {1,4,5,6}
 
 local mac = entity
 ------------------------------------------------------------------------------------------------------------------------
@@ -56,7 +56,7 @@ entity["fire_prof"] = 5
 entity["wind_prof"] = 1
 entity["ether_prof"] = 1
 
-entity["actions"] = {1,7}
+entity["actions"] = {1,7,8}
 
 local ken = entity
 ------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
made it so entities cant target dead enemy entities with single target abilities

now guard recharges a little at the start of an entity's turn